### PR TITLE
sqs-insight visibility fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /tmp/sqs-alpine
 RUN \
   apk add --update git \
   && rm -rf /var/cache/apk/* \
-  && git clone --verbose --depth=1 https://github.com/finanzcheck/sqs-insight.git \
+  && git clone --verbose --depth=1 https://github.com/kobim/sqs-insight.git \
   && curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-${jq_version}/jq-linux64 \
   && chmod +x /usr/local/bin/jq \
   && export server_version=$(curl -s https://api.github.com/repos/adamw/elasticmq/releases/latest | jq -r .tag_name | cut -d "-" -f 2) \

--- a/opt/sqs-insight.conf
+++ b/opt/sqs-insight.conf
@@ -7,7 +7,8 @@
            "key": "notValidKey",
            "secretKey": "notValidSecret",
            "region": "eu-central-1",
-           "url": "http://localhost:9324/queue/default"
+           "url": "http://localhost:9324/queue/default",
+           "visibility": 0
         }
     ]
 }

--- a/opt/sqs-insight/config/config_local.json
+++ b/opt/sqs-insight/config/config_local.json
@@ -7,7 +7,8 @@
            "key": "notValidKey",
            "secretKey": "notValidSecret",
            "region": "eu-central-1",
-           "url": "http://localhost:9324/queue/default"
+           "url": "http://localhost:9324/queue/default",
+           "visibility": 0
         }
     ]
 }


### PR DESCRIPTION
Closes #8

Because sqs-insight's default [_visibilityTimeout_](https://github.com/finanzcheck/sqs-insight/blob/e74556b63d94bc5c027a7eaf6c05429b37959112/lib/QueueMessageDispatcher.js#L50) is set to 10 seconds, each time a message in the queue is consumed by the web UI it isn't available to other consumers.

As [_finanzcheck/sqs-insight_](https://github.com/finanzcheck/sqs-insight) is archived, I [forked it](https://github.com/kobim/sqs-insight) and added an option to provide `visibliity` via the json config.

Using it locally:
```json
{
    "port": 9325,
    "rememberMessages": 100,

    "endpoints": [
        {
           "key": "notValidKey",
           "secretKey": "notValidSecret",
           "region": "eu-central-1",
           "url": "http://localhost:9324/queue/default",
           "visibility": 0
        }
    ]
}
```
works great, and allows me to publish messages and receive them at any time without a problem.