### PR TITLE
Issue-024: Follow HTTP redirects when querying elasticmq Github repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
   && git clone --verbose --depth=1 https://github.com/kobim/sqs-insight.git \
   && curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-${jq_version}/jq-linux64 \
   && chmod +x /usr/local/bin/jq \
-  && export elasticmq_version=$(curl -s https://api.github.com/repos/adamw/elasticmq/releases/latest | jq -r .tag_name) \
+  && export elasticmq_version=$(curl -sL https://api.github.com/repos/adamw/elasticmq/releases/latest | jq -r .tag_name) \
   && elasticmq_version=${elasticmq_version//v} \
   && curl -LO https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-${elasticmq_version}.jar \
   && mv elasticmq-server-${elasticmq_version}.jar elasticmq-server.jar


### PR DESCRIPTION
This addresses issue #24 where: After the latest docker build on the morning of Feb 25, 2019 the container stopped working correctly. Logs show:

```
2019-02-25 17:23:59,469 INFO spawned: 'elasticmq' with pid 36
Error: Invalid or corrupt jarfile /opt/elasticmq-server.jar
```