### PR TITLE
support linux/arm64/v8 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,46 +2,42 @@
 #
 # This file is part of alpine-sqs which is released under the GPLv3.
 # See https://github.com/roribio/alpine-sqs for details.
+ARG ARCH
 
-FROM appropriate/curl as Builder
-
-ARG jq_version=1.5
+FROM alpine:3.13 as builder
 
 WORKDIR /tmp/sqs-alpine
 
 RUN \
-  apk add --update git \
-  && rm -rf /var/cache/apk/* \
+  apk add --no-cache \
+    curl \
+    git \
+    jq \
   && git clone --verbose --depth=1 https://github.com/kobim/sqs-insight.git \
-  && curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-${jq_version}/jq-linux64 \
-  && chmod +x /usr/local/bin/jq \
   && export elasticmq_version=$(curl -sL https://api.github.com/repos/adamw/elasticmq/releases/latest | jq -r .tag_name) \
   && elasticmq_version=${elasticmq_version//v} \
-  && curl -LO https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-${elasticmq_version}.jar \
+  && curl -sLO https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-${elasticmq_version}.jar \
   && mv elasticmq-server-${elasticmq_version}.jar elasticmq-server.jar
 
-FROM anapsix/alpine-java:8
+FROM ${ARCH}/openjdk:8-alpine
+
 LABEL maintainer="Ronald E. Oribio R. https://github.com/roribio"
 
-COPY --from=Builder /tmp/sqs-alpine/ /opt/
+COPY --from=builder /tmp/sqs-alpine/ /opt/
 COPY etc/ /etc/
 COPY opt/ /opt/
 
 RUN \
-  apk add --update \
+  apk add --no-cache \
     nodejs \
     nodejs-npm \
     supervisor \
     libtasn1=4.14-r0 \
-  && apk upgrade musl \
-  && rm -rf \
-    /var/cache/apk/* \
-    /etc/supervisord.conf \
+  && rm -rf /etc/supervisord.conf \
   && ln -s /etc/supervisor/supervisord.conf /etc/supervisord.conf \
   && cd /opt/sqs-insight \
   && npm install
 
-EXPOSE 9324 9325 
+EXPOSE 9324 9325 9326
 
 ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
-

--- a/etc/supervisor/conf.d/elasticmq.conf
+++ b/etc/supervisor/conf.d/elasticmq.conf
@@ -1,9 +1,8 @@
 [program:elasticmq]
-command=/opt/jdk/bin/java -Dconfig.file=/opt/config/elasticmq.conf -jar /opt/elasticmq-server.jar
+command=/usr/bin/java -Dconfig.file=/opt/config/elasticmq.conf -jar /opt/elasticmq-server.jar
 priority=10
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true
-

--- a/etc/supervisor/conf.d/insight.conf
+++ b/etc/supervisor/conf.d/insight.conf
@@ -6,4 +6,3 @@ autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true
-

--- a/etc/supervisor/conf.d/sqs-init.conf
+++ b/etc/supervisor/conf.d/sqs-init.conf
@@ -7,4 +7,3 @@ startsec=0
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
-

--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -17,4 +17,3 @@ serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [include]
 files = /etc/supervisor/conf.d/*.conf
-

--- a/opt/elasticmq.conf
+++ b/opt/elasticmq.conf
@@ -34,4 +34,3 @@ queues {
         receiveMessageWait = 0 seconds
     }
 }
-

--- a/opt/sqs-init.sh
+++ b/opt/sqs-init.sh
@@ -13,4 +13,3 @@ cp /opt/config/sqs-insight.conf /opt/sqs-insight/config/config_local.json
 
 sleep 1
 exit 0
-

--- a/opt/sqs-insight.conf
+++ b/opt/sqs-insight.conf
@@ -1,5 +1,5 @@
 {
-    "port": 9325,
+    "port": 9326,
     "rememberMessages": 100,
 
     "endpoints": [],
@@ -14,4 +14,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
```
~$ docker buildx build --platform linux/arm64/v8 --build-arg ARCH=arm64v8 -t alpine-sqs .
[+] Building 121.1s (16/16) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 1.32kB                                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/arm64v8/openjdk:8-alpine                                                                                                                                                                                      2.5s
 => [internal] load metadata for docker.io/library/alpine:3.13                                                                                                                                                                                           1.6s
 => [auth] arm64v8/openjdk:pull token for registry-1.docker.io                                                                                                                                                                                           0.0s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                                                                                                                                                            0.0s
 => [stage-1 1/5] FROM docker.io/arm64v8/openjdk:8-alpine@sha256:ad0c0c268e337200ace4256a6c40ea7eb01c467bde519aae8a6dc8c6ac103d53                                                                                                                        6.3s
 => => resolve docker.io/arm64v8/openjdk:8-alpine@sha256:ad0c0c268e337200ace4256a6c40ea7eb01c467bde519aae8a6dc8c6ac103d53                                                                                                                                0.0s
 => => sha256:0362ad1dd800a9d92f8982fa28f173f9120266153830f990f7486f44b068968a 2.69MB / 2.69MB                                                                                                                                                           0.3s
 => => sha256:571218f61883d9b38dc66005a4777e0cf86a05d2a7c570efe58f952c28f6737a 239B / 239B                                                                                                                                                               0.3s
 => => sha256:abe576d65b4ce9e6c3d3055aa955a1677d0d36b0e952ed6f7516c84754d6ad61 70.74MB / 70.74MB                                                                                                                                                         4.6s
 => => sha256:ad0c0c268e337200ace4256a6c40ea7eb01c467bde519aae8a6dc8c6ac103d53 947B / 947B                                                                                                                                                               0.0s
 => => sha256:e4105db9d4690c236b378feec3c07e3dbcc9efbd7e4e51d0a5df9a3b01b9e372 3.40kB / 3.40kB                                                                                                                                                           0.0s
 => => extracting sha256:0362ad1dd800a9d92f8982fa28f173f9120266153830f990f7486f44b068968a                                                                                                                                                                0.2s
 => => extracting sha256:571218f61883d9b38dc66005a4777e0cf86a05d2a7c570efe58f952c28f6737a                                                                                                                                                                0.0s
 => => extracting sha256:abe576d65b4ce9e6c3d3055aa955a1677d0d36b0e952ed6f7516c84754d6ad61                                                                                                                                                                1.6s
 => [builder 1/3] FROM docker.io/library/alpine:3.13@sha256:08d6ca16c60fe7490c03d10dc339d9fd8ea67c6466dea8d558526b1330a85930                                                                                                                             0.9s
 => => resolve docker.io/library/alpine:3.13@sha256:08d6ca16c60fe7490c03d10dc339d9fd8ea67c6466dea8d558526b1330a85930                                                                                                                                     0.0s
 => => sha256:019c59128325536e838a5f36028db214335129f9aa83214cc2c60c10dc1797ac 528B / 528B                                                                                                                                                               0.0s
 => => sha256:85b71a783ad319b691c1c355dac52ddc07350e0f7d3c3541edbc5370b084445a 1.47kB / 1.47kB                                                                                                                                                           0.0s
 => => sha256:08d6ca16c60fe7490c03d10dc339d9fd8ea67c6466dea8d558526b1330a85930 1.64kB / 1.64kB                                                                                                                                                           0.0s
 => => sha256:2914792bc417803b2106001990194cc00cdd4b6fd97cd21a368f26148bc8e722 2.71MB / 2.71MB                                                                                                                                                           0.7s
 => => extracting sha256:2914792bc417803b2106001990194cc00cdd4b6fd97cd21a368f26148bc8e722                                                                                                                                                                0.2s
 => [internal] load build context                                                                                                                                                                                                                        0.0s
 => => transferring context: 589B                                                                                                                                                                                                                        0.0s
 => [builder 2/3] WORKDIR /tmp/sqs-alpine                                                                                                                                                                                                                0.1s
 => [builder 3/3] RUN   apk add --no-cache     curl     git     jq   && git clone --verbose --depth=1 https://github.com/kobim/sqs-insight.git   && export elasticmq_version=$(curl -sL https://api.github.com/repos/adamw/elasticmq/releases/latest |   9.2s
 => [stage-1 2/5] COPY --from=builder /tmp/sqs-alpine/ /opt/                                                                                                                                                                                             0.1s
 => [stage-1 3/5] COPY etc/ /etc/                                                                                                                                                                                                                        0.0s
 => [stage-1 4/5] COPY opt/ /opt/                                                                                                                                                                                                                        0.0s
 => [stage-1 5/5] RUN   apk add --no-cache     nodejs     nodejs-npm     supervisor     libtasn1=4.14-r0   && rm -rf     /var/cache/apk/*     /etc/supervisord.conf   && ln -s /etc/supervisor/supervisord.conf /etc/supervisord.conf   && cd /opt/sq  105.3s
 => exporting to image                                                                                                                                                                                                                                   2.7s
 => => exporting layers                                                                                                                                                                                                                                  2.7s
 => => writing image sha256:31b8c9c1b99912ac965696873a0e9f08f2bab2a426dafde93e50e79c3c78dfd0                                                                                                                                                             0.0s
 => => naming to docker.io/library/alpine-sqs                                                                                                                                                                                                            0.0s
```