### PR TITLE
Updated to support the ElasticMQ JSON protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN \
   && cd /opt/sqs-insight \
   && npm install
 
-EXPOSE 9324 9325 
+EXPOSE 9324 9325 9326
 
 ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM appropriate/curl as Builder
 
-ARG jq_version=1.5
+ARG elasticmq_version=1.6.1
 
 WORKDIR /tmp/sqs-alpine
 
@@ -13,10 +13,6 @@ RUN \
   apk add --update git \
   && rm -rf /var/cache/apk/* \
   && git clone --verbose --depth=1 https://github.com/kobim/sqs-insight.git \
-  && curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-${jq_version}/jq-linux64 \
-  && chmod +x /usr/local/bin/jq \
-  && export elasticmq_version=$(curl -sL https://api.github.com/repos/adamw/elasticmq/releases/latest | jq -r .tag_name) \
-  && elasticmq_version=${elasticmq_version//v} \
   && curl -LO https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-${elasticmq_version}.jar \
   && mv elasticmq-server-${elasticmq_version}.jar elasticmq-server.jar
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Depending on how you chose to install the environment, you can initialize it in 
 Use this method if you're pulling directly from Docker Hub and do not have a `docker-compose.yml` file.
 
 ```
-docker run --name alpine-sqs -p 9324:9324 -p 9325:9325 -d roribio16/alpine-sqs:latest
+docker run --name alpine-sqs -p 9324:9324 -p 9326:9326 -d roribio16/alpine-sqs:latest
 ```
 
 Custom configuration files may be used to override default behaviors. You can mount a volume mapping the container's `/opt/custom` directory to a folder in your host machine where the custom configuration files are stored.
@@ -74,7 +74,7 @@ Custom configuration files may be used to override default behaviors. You can mo
 Providing for sake of example that in your host machine directory `/opt/alpine-sqs` you have both `elasticmq.conf` and `sqs-insight.conf` files, you can run the container with:
 
 ```
-docker run --name alpine-sqs -p 9324:9324 -p 9325:9325 -v /opt/alpine-sqs:/opt/custom -d roribio16/alpine-sqs:latest
+docker run --name alpine-sqs -p 9324:9324 -p 9326:9326 -v /opt/alpine-sqs:/opt/custom -d roribio16/alpine-sqs:latest
 ```
 
 For any configuration file not explicitly included in the container's `/opt/custom` directory, `alpine-sqs` will fall back to using the default configuration files listed [here](https://github.com/roribio/alpine-sqs/tree/master/opt).
@@ -116,13 +116,15 @@ aws --endpoint-url http://localhost:9324 sqs send-message --queue-url http://loc
 ```
 
 #### Viewing messages
-To view messages, navigate to the web UI ([sqs-insight](https://github.com/finanzcheck/sqs-insight)) by pointing your web browser to `http://localhost:9325`.
+To view messages, navigate to the web UI ([sqs-insight](https://github.com/finanzcheck/sqs-insight)) by pointing your web browser to `http://localhost:9326`.
 
 You can also poll for messages from the command-line like so:
 
 ```
 aws --endpoint-url http://localhost:9324 sqs receive-message --queue-url http://localhost:9324/queue/default --wait-time-seconds 10
 ```
+
+> **Note**: The web UI previously was hosted on port 9325 but has been moved to 9326. Later versions of ElasticMQ host a stats API on port 9325 so the web UI was moved.
 
 ### Creating new queues
 You can create new queues by using the command-line or configuring ElasticMQ directly.

--- a/opt/sqs-insight.conf
+++ b/opt/sqs-insight.conf
@@ -1,5 +1,5 @@
 {
-    "port": 9325,
+    "port": 9326,
     "rememberMessages": 100,
 
     "endpoints": [],

--- a/opt/sqs-insight/config/config_local.json
+++ b/opt/sqs-insight/config/config_local.json
@@ -1,5 +1,5 @@
 {
-    "port": 9325,
+    "port": 9326,
     "rememberMessages": 100,
 
     "endpoints": [


### PR DESCRIPTION
This changeset is to allow for updating ElasticMQ to a version new enough to support the JSON protocol which later versions of the aws-sdk-go-v2 require. For this to happen a few changes were necessary:

- Modified `Dockerfile` to no longer use `jq` to dynamically determine ElasticMQ version and pinned the ElasticMQ version to 1.6.1.
- Modified the sqs-insight configuration to run on port 9326. This was necessary because later versions of ElasticMQ expose a stats API on port 9325.
- Updated `README.md` to indicate the web UI now runs on port 9326.